### PR TITLE
Fix #1

### DIFF
--- a/root/app/resources/ydl.py
+++ b/root/app/resources/ydl.py
@@ -107,7 +107,7 @@ def download(args):
             for f in Path(tmpdir).glob('**/*'):
                 subdir = join(dl_path, dirname(relpath(f, tmpdir)))
                 os.makedirs(subdir, exist_ok=True)
-                shutil.move(f, join(dl_path, relpath(f, tmpdir)))
+                shutil.move(str(f), join(dl_path, relpath(f, tmpdir)))
         except Exception as e:
             print(e)
             print('Consider setting "YTBDL_I=true" to ignore youtube-dl errors')


### PR DESCRIPTION
When call `shutil.move` and dst is dir, shutil will get real dst with `_basename(src)`:

```python
def _basename(path):
    # A basename() variant which first strips the trailing slash, if present.
    # Thus we always get the last component of the path, even for directories.
    sep = os.path.sep + (os.path.altsep or '')
    return os.path.basename(path.rstrip(sep))
```